### PR TITLE
Adopt for last changes

### DIFF
--- a/src/QueryDataReader.php
+++ b/src/QueryDataReader.php
@@ -14,7 +14,7 @@ namespace Yiisoft\Data\Db;
  */
 final class QueryDataReader extends AbstractQueryDataReader
 {
-    protected function createItem(array $row): array
+    protected function createItem(array|object $row): array|object
     {
         /** @psalm-var TValue */
         return $row;

--- a/tests/DataReaderTest.php
+++ b/tests/DataReaderTest.php
@@ -5,8 +5,33 @@ declare(strict_types=1);
 namespace Yiisoft\Data\Db\Tests;
 
 use PHPUnit\Framework\TestCase;
+use stdClass;
+use Yiisoft\Data\Db\Filter\Between;
+use Yiisoft\Data\Db\Filter\Equals;
+use Yiisoft\Data\Db\Filter\GreaterThan;
+use Yiisoft\Data\Db\Filter\GreaterThanOrEqual;
+use Yiisoft\Data\Db\Filter\ILike;
+use Yiisoft\Data\Db\Filter\In;
+use Yiisoft\Data\Db\Filter\LessThan;
+use Yiisoft\Data\Db\Filter\LessThanOrEqual;
+use Yiisoft\Data\Db\Filter\Like;
+use Yiisoft\Data\Db\Filter\NotEquals;
+use Yiisoft\Data\Db\FilterHandler\BetweenHandler;
+use Yiisoft\Data\Db\FilterHandler\EqualsHandler;
+use Yiisoft\Data\Db\FilterHandler\GreaterThanHandler;
+use Yiisoft\Data\Db\FilterHandler\GreaterThanOrEqualHandler;
+use Yiisoft\Data\Db\FilterHandler\ILikeHandler;
+use Yiisoft\Data\Db\FilterHandler\InHandler;
+use Yiisoft\Data\Db\FilterHandler\LessThanHandler;
+use Yiisoft\Data\Db\FilterHandler\LessThanOrEqualHandler;
+use Yiisoft\Data\Db\FilterHandler\LikeHandler;
+use Yiisoft\Data\Db\FilterHandler\NotEqualsHandler;
 use Yiisoft\Data\Db\QueryDataReader;
+use Yiisoft\Data\Db\Tests\Support\CustomerDataReader;
+use Yiisoft\Data\Db\Tests\Support\CustomerDTO;
+use Yiisoft\Data\Db\Tests\Support\CustomerQuery;
 use Yiisoft\Data\Db\Tests\Support\TestTrait;
+use Yiisoft\Data\Reader\FilterInterface;
 use Yiisoft\Data\Reader\Sort;
 use Yiisoft\Db\Expression\Expression;
 use Yiisoft\Db\Query\Query;
@@ -42,8 +67,8 @@ final class DataReaderTest extends TestCase
         $actual = $dataReader->getPreparedQuery()->createCommand()->getRawSql();
         $expected = $query->createCommand()->getRawSql();
 
-        $this->assertSame($expected, $actual);
-        $this->assertStringEndsWith('OFFSET 2', $actual);
+        self::assertSame($expected, $actual);
+        self::assertStringEndsWith('OFFSET 2', $actual);
     }
 
     public function testLimit(): void
@@ -62,8 +87,8 @@ final class DataReaderTest extends TestCase
         $actual = $dataReader->getPreparedQuery()->createCommand()->getRawSql();
         $expected = $query->createCommand()->getRawSql();
 
-        $this->assertSame($expected, $actual);
-        $this->assertStringEndsWith('LIMIT 1 OFFSET 1', $actual);
+        self::assertSame($expected, $actual);
+        self::assertStringEndsWith('LIMIT 1 OFFSET 1', $actual);
     }
 
     public function sortDataProvider(): array
@@ -132,9 +157,125 @@ final class DataReaderTest extends TestCase
         $dataReader = (new QueryDataReader($query))
             ->withSort($sort);
 
-        $this->assertStringEndsWith(
+        self::assertStringEndsWith(
             $expected,
             $dataReader->getPreparedQuery()->createCommand()->getRawSql()
         );
+    }
+
+    public static function handlerDataProvider(): array
+    {
+        return [
+            [
+                new Equals('equals', 1),
+                EqualsHandler::class,
+            ],
+            [
+                new Between('column', [100, 300]),
+                BetweenHandler::class,
+            ],
+            [
+                new GreaterThan('column', 1000),
+                GreaterThanHandler::class,
+            ],
+            [
+                new GreaterThanOrEqual('column', 3.5),
+                GreaterThanOrEqualHandler::class,
+            ],
+            [
+                new LessThan('column', 10.7),
+                LessThanHandler::class,
+            ],
+            [
+                new LessThanOrEqual('column', 100),
+                LessThanOrEqualHandler::class,
+            ],
+            [
+                new In('column', [10, 20, 30]),
+                InHandler::class,
+            ],
+            [
+                new NotEquals('column', 40),
+                NotEqualsHandler::class,
+            ],
+            [
+                new Like('column', 'foo'),
+                LikeHandler::class,
+            ],
+            [
+                new ILike('column', 'foo'),
+                ILikeHandler::class,
+            ],
+        ];
+    }
+
+    public function testCount(): void
+    {
+        $query = new CustomerQuery($this->getConnection());
+        $dataReader = (new CustomerDataReader($query));
+
+        self::assertEquals($query->count(), $dataReader->count());
+    }
+
+    /**
+     * @dataProvider handlerDataProvider
+     * @param FilterInterface $filter
+     * @param string $handler
+     * @return void
+     */
+    public function testHandlerByOperation(FilterInterface $filter, string $handler): void
+    {
+        $db = $this->getConnection();
+
+        $query = (new Query($db))
+            ->from('customer');
+
+        $dataReader = new QueryDataReader($query);
+        $filterHandler = $dataReader->getHandlerByOperation($filter);
+        $filterOperatorHandler = $dataReader->getHandlerByOperation($filter::getOperator());
+
+        self::assertInstanceOf($handler, $filterHandler);
+        self::assertInstanceOf($handler, $filterOperatorHandler);
+    }
+
+    public function testDtoCreateItem(): void
+    {
+        $query = new CustomerQuery($this->getConnection());
+        $dataReader = (new CustomerDataReader($query))
+            ->withBatchSize(null);
+
+
+        self::assertInstanceOf(CustomerDTO::class, $dataReader->readOne());
+
+        foreach ($dataReader->read() as $row) {
+            self::assertInstanceOf(CustomerDTO::class, $row);
+        }
+    }
+
+    public function testObjectCreateItem(): void
+    {
+        $query = (new CustomerQuery($this->getConnection()))
+            ->asObject(true);
+        $dataReader = (new QueryDataReader($query))
+            ->withBatchSize(null);
+
+        self::assertInstanceOf(stdClass::class, $dataReader->readOne());
+
+        foreach ($dataReader->read() as $row) {
+            self::assertInstanceOf(stdClass::class, $row);
+        }
+    }
+
+    public function testArrayCreateItem(): void
+    {
+        $query = new CustomerQuery($this->getConnection());
+        $dataReader = (new QueryDataReader($query))
+            ->withBatchSize(null);
+
+        self::assertIsArray($dataReader->readOne());
+
+        foreach ($dataReader->read() as $row) {
+            self::assertIsArray($row);
+        }
     }
 }

--- a/tests/Support/CustomerDTO.php
+++ b/tests/Support/CustomerDTO.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Data\Db\Tests\Support;
+
+final class CustomerDTO
+{
+}

--- a/tests/Support/CustomerDataReader.php
+++ b/tests/Support/CustomerDataReader.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Data\Db\Tests\Support;
+
+use Yiisoft\Data\Db\AbstractQueryDataReader;
+
+final class CustomerDataReader extends AbstractQueryDataReader
+{
+
+    /**
+     * @inheritDoc
+     */
+    protected function createItem(object|array $row): array|object
+    {
+        return new CustomerDTO();
+    }
+}

--- a/tests/Support/CustomerQuery.php
+++ b/tests/Support/CustomerQuery.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Data\Db\Tests\Support;
+
+use Yiisoft\Db\Query\Query;
+use function count;
+
+final class CustomerQuery extends Query
+{
+    private array $data = [
+        [
+            'id' => 1,
+            'email' => 'user1@example.com',
+            'user1' => 'address1',
+        ],
+        [
+            'id' => 2,
+            'email' => 'user2@example.com',
+            'user1' => 'address2',
+        ],
+        [
+            'id' => 3,
+            'email' => 'user3@example.com',
+            'user1' => 'address3',
+        ]
+    ];
+
+    public function all(): array
+    {
+        return $this->data;
+    }
+
+    public function one(): ?array
+    {
+        return $this->data[0];
+    }
+
+    public function count(string $q = '*'): int|string
+    {
+        return count($this->data);
+    }
+
+    public function asObject(bool $value): self
+    {
+        if ($value) {
+            $this->data = array_map(static fn ($item) => (object) $item, $this->data);
+        } else {
+            $this->data = array_map(static fn ($item) => (array) $item, $this->data);
+        }
+
+        return $this;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌

1. Change input type for `createItem` to `array|object`
2. Allow `readOne` and `getIterator` to `createItem`
3. Change access `getHandlerByOperation` to `public`. It can be useful for some cases like

```
$arQuery->with([
       'relation' => function($query) use ($dataReader, $filter) { 
               $handler = $dataReader->getHandlerByOperation($filter);
               $handler->applyFilter($query, $filter);
       }
])

```
